### PR TITLE
Method to update list item text

### DIFF
--- a/include/overlay/elements/list_item.hpp
+++ b/include/overlay/elements/list_item.hpp
@@ -40,6 +40,8 @@ namespace tsl::element {
 
         void setClickListener(std::function<bool(s64 keysDown)> clickListener) { this->m_clickListener = clickListener; }
 
+        void updateText(std::string text);
+
     private:
         std::string m_text;
         std::function<bool(s64 keysDown)> m_clickListener = nullptr;

--- a/include/overlay/elements/list_item.hpp
+++ b/include/overlay/elements/list_item.hpp
@@ -40,7 +40,7 @@ namespace tsl::element {
 
         void setClickListener(std::function<bool(s64 keysDown)> clickListener) { this->m_clickListener = clickListener; }
 
-        void updateText(std::string text);
+        void setText(std::string text);
 
     private:
         std::string m_text;

--- a/source/overlay/elements/list_item.cpp
+++ b/source/overlay/elements/list_item.cpp
@@ -55,4 +55,8 @@ namespace tsl::element {
         return false;
     }
 
+    void ListItem::updateText(std::string text) {
+        this->m_text = text;
+    }
+
 }

--- a/source/overlay/elements/list_item.cpp
+++ b/source/overlay/elements/list_item.cpp
@@ -55,7 +55,7 @@ namespace tsl::element {
         return false;
     }
 
-    void ListItem::updateText(std::string text) {
+    void ListItem::setText(std::string text) {
         this->m_text = text;
     }
 


### PR DESCRIPTION
Allows list item text to be updated even after returning from `createUI()`