### PR TITLE
Fix OverlayFrame crash with no content

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -770,7 +770,10 @@ namespace tsl {
             }
 
             virtual Element* requestFocus(Element *oldFocus, FocusDirection direction) override {
-                return this->m_contentElement->requestFocus(oldFocus, direction);
+                if (this->m_contentElement != nullptr)
+                    return this->m_contentElement->requestFocus(oldFocus, direction);
+                else
+                    return nullptr;
             }
 
             virtual void setContent(Element *content) final {


### PR DESCRIPTION
Fixes crash when createUI returns an OverlayFrame without setting its content