### PR TITLE
Fix crash when change gui from handleInput

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -34,6 +34,8 @@
 #include <mutex>
 #include <memory>
 #include <chrono>
+#include <list>
+#include <stack>
 #include <map>
 
 
@@ -1623,7 +1625,7 @@ namespace tsl {
          * @return Current Gui reference
          */
         virtual std::unique_ptr<tsl::Gui>& getCurrentGui() final {
-            return this->m_guiStack[this->m_guiStack.size() - 1];
+            return this->m_guiStack.top();
         }
 
         /**
@@ -1697,9 +1699,9 @@ namespace tsl {
             newGui->m_topElement = newGui->createUI();
             newGui->requestFocus(newGui->m_topElement, FocusDirection::None);
 
-            this->m_guiStack.push_back(std::move(newGui));
+            this->m_guiStack.push(std::move(newGui));
 
-            return this->m_guiStack.back();
+            return this->m_guiStack.top();
         }
 
         /**
@@ -1712,9 +1714,9 @@ namespace tsl {
             gui->m_topElement = gui->createUI();
             gui->requestFocus(gui->m_topElement, FocusDirection::None);
 
-            this->m_guiStack.push_back(std::move(gui));
+            this->m_guiStack.push(std::move(gui));
 
-            return this->m_guiStack.back();
+            return this->m_guiStack.top();
         }
 
         /**
@@ -1722,15 +1724,16 @@ namespace tsl {
          * @note The Overlay gets closes once there are no more Guis on the stack
          */
         void goBack() {
-            if (this->m_guiStack.size() > 0)
-                this->m_guiStack.pop_back();
+            if (!this->m_guiStack.empty())
+                this->m_guiStack.pop();
 
-            if (this->m_guiStack.size() == 0)
+            if (this->m_guiStack.empty())
                 this->close();
         }
 
-    private:       
-        std::vector<std::unique_ptr<tsl::Gui>> m_guiStack;
+    private:
+        using GuiPtr = std::unique_ptr<tsl::Gui>;
+        std::stack<GuiPtr, std::list<GuiPtr>> m_guiStack;
         
         bool m_fadeInAnimationPlaying = true, m_fadeOutAnimationPlaying = false;
         u8 m_animationCounter = 0;


### PR DESCRIPTION
If `onClick` in `handleInput` calls `changeTo` to put new gui onto `m_guiStack`, the vector may resize and cause the `currentGui` reference to no longer be valid, causing a crash.