### PR TITLE
Improve input detection at low framerate

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -1664,6 +1664,15 @@ namespace tsl {
         }
 
         /**
+         * @brief Returns whether fade animation is playing
+         *
+         * @return whether fade animation is playing
+         */
+        virtual bool fadeAnimationPlaying() final {
+            return this->m_fadeInAnimationPlaying || this->m_fadeOutAnimationPlaying;
+        }
+
+        /**
          * @brief Closes the Gui
          * @note This makes the Tesla overlay exit and return back to the Tesla-Menu
          * 
@@ -1937,6 +1946,7 @@ namespace tsl {
 
             std::mutex dataMutex;
             u64 keysDown = 0;
+            u64 keysDownPending = 0;
             u64 keysHeld = 0;
             touchPosition touchPos = { 0 };
             JoystickPosition joyStickPosLeft = { 0 }, joyStickPosRight = { 0 };
@@ -2025,22 +2035,23 @@ namespace tsl {
                     hidJoystickRead(&shData->joyStickPosLeft, CONTROLLER_HANDHELD, HidControllerJoystick::JOYSTICK_LEFT);
                     hidJoystickRead(&shData->joyStickPosRight, CONTROLLER_HANDHELD, HidControllerJoystick::JOYSTICK_RIGHT);
 
-                }
-
-                if (((shData->keysHeld & shData->launchCombo) == shData->launchCombo) && shData->keysDown & shData->launchCombo) {
-                    if (shData->overlayOpen) {
-                        tsl::Overlay::get()->hide();
-                        shData->overlayOpen = false;
+                    if (((shData->keysHeld & shData->launchCombo) == shData->launchCombo) && shData->keysDown & shData->launchCombo) {
+                        if (shData->overlayOpen) {
+                            tsl::Overlay::get()->hide();
+                            shData->overlayOpen = false;
+                        }
+                        else
+                            eventFire(&shData->comboEvent);
                     }
-                    else
-                        eventFire(&shData->comboEvent);
-                }
 
-                if (shData->touchPos.px >= cfg::FramebufferWidth && shData->overlayOpen) {
-                    if (shData->overlayOpen) {
-                        tsl::Overlay::get()->hide();
-                        shData->overlayOpen = false;
+                    if (shData->touchPos.px >= cfg::FramebufferWidth && shData->overlayOpen) {
+                        if (shData->overlayOpen) {
+                            tsl::Overlay::get()->hide();
+                            shData->overlayOpen = false;
+                        }
                     }
+
+                    shData->keysDownPending |= shData->keysDown;
                 }
 
                 //20 ms
@@ -2179,10 +2190,10 @@ namespace tsl {
 
                 {
                     std::scoped_lock lock(shData.dataMutex);
-                    overlay->handleInput(shData.keysDown, shData.keysHeld, shData.touchPos, shData.joyStickPosLeft, shData.joyStickPosRight);
-
-                    shData.keysDown = 0x00;
-                    shData.keysHeld = 0x00;
+                    if (!overlay->fadeAnimationPlaying()) {
+                        overlay->handleInput(shData.keysDownPending, shData.keysHeld, shData.touchPos, shData.joyStickPosLeft, shData.joyStickPosRight);
+                    }
+                    shData.keysDownPending = 0;
                 }
 
                 if (overlay->shouldHide())


### PR DESCRIPTION
This PR fixes 2 issues:
1. `keysDown` is sometimes missed on main thread when framerate is low
2. When triggering combo, the keys used are also being handled by overlay

The first issue happens when the hid thread loops twice, setting keysDown and then unsetting it in the second loop before the main thread has a chance to read the keys state. The hid thread now aggregates key downs into `keysDownPending` shared data, which is only cleared by the main thread when it has a chance to read it. This solution also works for very low fps situation where the user presses and releases a key within the duration of a single frame.

The second issue happens because handleInput in the main thread is called even while overlay is fading in/out. I moved the overlay hide/show blocks in the hid thread into the mutex block because there's a race condition in which the main thread could read the combo before the hid thread sets the fading flags. Didn't notice any fps drop from this change.