### PR TITLE
Fix goBack from click listener crash

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -1816,6 +1816,9 @@ namespace tsl {
                 parentElement = parentElement->getParent();
             } while (!handled && parentElement != nullptr);
 
+            if (currentGui != this->getCurrentGui())
+                return;
+
             handled = handled | currentGui->handleInput(keysDown, keysHeld, touchPos, joyStickPosLeft, joyStickPosRight);
 
             if (!handled) {


### PR DESCRIPTION
Go back from element handler crashes because gui is destroyed when popped from the stack, but gui input handler is still fired afterwards