### PR TITLE
Vi

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -1029,6 +1029,8 @@ namespace tsl {
                 nwindowClose(&this->m_window);
                 viCloseLayer(&this->m_layer);
                 viDestroyManagedLayer(&layerCopy); // Copy is required because viCloseLayer wipes the passed layer object
+                viCloseDisplay(&this->m_display);
+                eventClose(&this->m_vsyncEvent);
                 viExit();
             }
 

--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -1023,12 +1023,9 @@ namespace tsl {
                 if (!this->m_initialized)
                     return;
 
-                ViLayer layerCopy = this->m_layer;
-
                 framebufferClose(&this->m_framebuffer);
                 nwindowClose(&this->m_window);
-                viCloseLayer(&this->m_layer);
-                viDestroyManagedLayer(&layerCopy); // Copy is required because viCloseLayer wipes the passed layer object
+                viDestroyManagedLayer(&this->m_layer);
                 viCloseDisplay(&this->m_display);
                 eventClose(&this->m_vsyncEvent);
                 viExit();


### PR DESCRIPTION
- vsync event and display were never closed
- viCloseLayer returns 0xa72 on managed layers