### PR TITLE
Call stateChangedListener on setState

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -2304,10 +2304,7 @@ namespace tsl {
 
             virtual bool onClick(u64 keys) override {
                 if (keys & KEY_A) {
-                    this->m_state = !this->m_state;
-
-                    this->setState(this->m_state);
-                    this->m_stateChangedListener(this->m_state);
+                    this->setState(!this->m_state);
 
                     return ListItem::onClick(keys);
                 }
@@ -2330,12 +2327,16 @@ namespace tsl {
              * @param state State
              */
             virtual void setState(bool state) {
+                bool stateChanged = state != this->m_state;
                 this->m_state = state;
 
                 if (state)
                     this->setValue(this->m_onValue, false);
                 else
                     this->setValue(this->m_offValue, true);
+                
+                if(stateChanged && this->m_stateChangedListener)
+                    this->m_stateChangedListener(state);
             }
 
             /**


### PR DESCRIPTION
setState should call stateChangedListener if state actually changed, rather than onClick()

Still calls the setValue() portion anyway because the default behavior depends on this to set the initial "On"/"Off" markers.