### PR TITLE
Fix hid breakage (breaks AMS button detection and possibly more)

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -3384,7 +3384,7 @@ namespace tsl {
             impl::parseOverlaySettings();
 
             // Configure input to take all controllers and up to 8
-            padConfigureInput(8, HidNpadStyleSet_NpadStandard);
+            padConfigureInput(8, HidNpadStyleSet_NpadStandard | HidNpadStyleTag_NpadSystemExt);
 
             // Initialize pad
             PadState pad;


### PR DESCRIPTION
Since https://github.com/WerWolv/libtesla/commit/bfe12ab0900ec5d1f5d8f2d97ce72e992571ae51 , anything compiled with latest libtesla would break AMS' button bindings (to launch hbmenu or whatever) unless you further launched anything else using the old HID api (which called hidSetSupportedNpadStyleSet with HidNpadStyleTag_NpadSystemExt, apparently fixing this issue). This can easily be reproduced with the tesla menu.