### PR TITLE
Update Example Makefile to C++20

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -59,7 +59,7 @@ CFLAGS	:=	-g -Wall -O2 -ffunction-sections \
 
 CFLAGS	+=	$(INCLUDE) -D__SWITCH__
 
-CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=c++17
+CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=c++20
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)


### PR DESCRIPTION
Updating the example's makefile to use C++ 20.
C++ 17 does not have `std::bit_cast` which is now in use in `tesla.hpp` which prevented the example from being built.