### PR TITLE
Workaround race condition causing crash in docked mode

### DIFF
--- a/include/tesla.hpp
+++ b/include/tesla.hpp
@@ -1079,7 +1079,25 @@ namespace tsl {
                 if (!this->m_initialized)
                     return;
 
-                framebufferClose(&this->m_framebuffer);
+                //framebufferClose(&this->m_framebuffer);
+                Framebuffer* fb = &this->m_framebuffer;
+                if (!fb || !fb->has_init)
+                    return;
+
+                if (fb->buf_linear)
+                    free(fb->buf_linear);
+
+                if (fb->buf) {
+                    nwindowReleaseBuffers(fb->win);
+                    nvMapClose(&fb->map);
+                    free(fb->buf);
+                }
+
+                memset(fb, 0, sizeof(*fb));
+                nvFenceExit();
+                nvMapExit();
+                svcSleepThread(10'000'000);
+                nvExit();
                 nwindowClose(&this->m_window);
                 viDestroyManagedLayer(&this->m_layer);
                 viCloseDisplay(&this->m_display);


### PR DESCRIPTION
Tested it by myself and Monked, no crash in docked mode since I have used this trick which is:
- copy FramebufferClose code from libnx ([LINK](https://github.com/switchbrew/libnx/blob/master/nx/source/display/framebuffer.c#L137-L152))
- Delay using nvExit()

Sleep is short enough to not cause any visible performance drop when switching between overlays.